### PR TITLE
Odpočet busy času

### DIFF
--- a/src/Controller/MapController.php
+++ b/src/Controller/MapController.php
@@ -168,7 +168,7 @@ class MapController extends AbstractController
         $action = new Action();
         $action->setUser($user);
         $action->setType(ActionTypes::MOVE);
-        $action->setRunTime(new \DateTime('1 minute'));
+        $action->setRunTime(new \DateTime('2 minute'));
         $action->setData([ 'x' => $x, 'y' => $y ]);
 
         $this->doctrine->getManager()->persist($action);

--- a/src/Controller/MapController.php
+++ b/src/Controller/MapController.php
@@ -44,7 +44,7 @@ class MapController extends AbstractController
         $current = null;
 
         if($user->getBusyTill() != null) {
-            $busy = $user->getBusyTill() > new \DateTime() ? $user->getBusyTill()->format('H:i') : null;
+            $busy = $user->getBusyTill() > new \DateTime() ? $user->getBusyTill() : null;
         }
 
         // dočasná hovadinka, která se později zcela nahradí

--- a/src/Controller/SquadController.php
+++ b/src/Controller/SquadController.php
@@ -82,7 +82,7 @@ class SquadController extends AbstractController
         $action = new Action();
         $action->setUser($user);
         $action->setType(ActionTypes::REST);
-        $action->setRunTime(new \DateTime('4 minute'));
+        $action->setRunTime(new \DateTime('5 minute'));
 
         $this->doctrine->getManager()->persist($action);
         $this->doctrine->getManager()->flush();

--- a/src/Controller/SquadController.php
+++ b/src/Controller/SquadController.php
@@ -37,7 +37,7 @@ class SquadController extends AbstractController
         $current = null;
 
         if($user->getBusyTill() != null) {
-            $busy = $user->getBusyTill() > new \DateTime() ? $user->getBusyTill()->format('H:i') : null;
+            $busy = $user->getBusyTill() > new \DateTime() ? $user->getBusyTill() : null;
         }
 
         $currentAction = $this->actionRepository->findUserCurrentAction($user);

--- a/templates/parts/busy.twig
+++ b/templates/parts/busy.twig
@@ -1,6 +1,6 @@
 {% if busy %}
     <div class="busy">
-        <p class="red">Tvá jednotka právě plní rozkaz, bude zaneprázdněná až do {{ busy }}</p>
+        <p class="red">Tvá jednotka právě plní rozkaz, bude zaneprázdněná ještě <span class="busy-time" data-end-at="{{ busy|date("U") }}"></span></p>
         {% if current %}
             {% if current.type.value == 1 %}
                 <p class="yellow">Právě probíhá přesun na souřadnice {{ current.data.x }},{{ current.data.y }}</p>
@@ -9,4 +9,38 @@
             {% endif %}
         {% endif %}
     </div>
+
+    <script>
+        document.addEventListener('DOMContentLoaded', function() {
+            var busyTime = document.querySelector('.busy-time');
+            const busyTimeEnd = busyTime.dataset.endAt;
+
+            const actualTime = new Date().getTime() / 1000;
+            if(busyTimeEnd > actualTime) {
+                updateTime(busyTimeEnd);
+                setInterval(updateTime, 1000, busyTimeEnd);
+            }else{
+                location.reload();
+            }
+        });
+
+        function updateTime(busyTimeEnd)
+        {
+            var busyTime = document.querySelector('.busy-time');
+            const actualTime = new Date().getTime() / 1000;
+            var seconds = Math.max(0, Math.floor(busyTimeEnd - actualTime));
+            let minutes = 0;
+
+            while(seconds > 59){
+                seconds = seconds - 60;
+                minutes++;
+            }
+            const formateText = `${minutes.toString().padStart(2, '0')}:${seconds.toString().padStart(2, '0')}`;
+            busyTime.innerHTML = formateText;
+
+            if(minutes == 0 && seconds < 1) return setTimeout(function () {
+                location.reload();
+            }, 2000);
+        }
+    </script>
 {% endif %}


### PR DESCRIPTION
Přidání odpočtu busy času, s tím že se zobrazuje odpočet následovně: `Tvá jednotka právě plní rozkaz, bude zaneprázdněná ještě 02:00`. A zároveň po odpočtu, vyčká 2vteřiny před znovunačtením stránky (Aby se stihli vykonat serverside záležitosti, mnohdy zůstávala šipka od akce na mapě).
Oprava action času, kdy tedy u odpočinku a pohybu, byl action čas o minutu kratší než busy čas.

Closes #14 